### PR TITLE
Add WH IBC Info

### DIFF
--- a/ibc_info.json
+++ b/ibc_info.json
@@ -33,7 +33,7 @@
       "dst_channel": "channel-0",
       "src_channel": "channel-4",
       "port_id": "wasm.sei1gjrrme22cyha4ht2xapn3f08zzw6z3d4uxx6fyy9zd5dyr3yxgzqqncdqn",
-      "client_id": " 07-tendermint-12"
+      "client_id": "07-tendermint-12"
     }
   ],
   "atlantic-2": [
@@ -56,7 +56,7 @@
       "dst_channel": "channel-3",
       "src_channel": "channel-15",
       "port_id": "wasm.sei1nna9mzp274djrgzhzkac2gvm3j27l402s4xzr08chq57pjsupqnqaj0d5s",
-      "client_id": " 07-tendermint-12"
+      "client_id": "07-tendermint-55"
     }
   ]
 }


### PR DESCRIPTION
- Adds WH IBC info for channel between SEI <> Wormchain
- Bridging out via WH uses IBC channel from sei <> Wormchain

Verified IBC info:
```Atlantic-2
client_id: 07-tendermint-55

channel_id: channel-15
  connection_hops:
  - connection-29
  counterparty:
    channel_id: channel-3
    port_id: wasm.wormhole1nc5tatafv6eyq7llkr2gv50ff9e22mnf70qgjlv737ktmt4eswrq0kdhcj
  ordering: ORDER_UNORDERED
  port_id: wasm.sei1nna9mzp274djrgzhzkac2gvm3j27l402s4xzr08chq57pjsupqnqaj0d5s
  state: STATE_OPEN
  version: ibc-wormhole-v1



Pacific-1
07-tendermint-12

channel_id: channel-4
  connection_hops:
  - connection-6
  counterparty:
    channel_id: channel-0
    port_id: wasm.wormhole1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5ws2y050r
  ordering: ORDER_UNORDERED
  port_id: wasm.sei1gjrrme22cyha4ht2xapn3f08zzw6z3d4uxx6fyy9zd5dyr3yxgzqqncdqn
  state: STATE_OPEN
  version: ibc-wormhole-v1```