### PR TITLE
Improve USDC flavour tickers

### DIFF
--- a/assetlist.json
+++ b/assetlist.json
@@ -23,7 +23,7 @@
     {
       "name": "USD Coin (Axelar)",
       "description": "Circle's stablecoin on Axelar",
-      "symbol": "axlUSDC",
+      "symbol": "axl.USDC",
       "base": "ibc/F082B65C88E4B6D5EF1DB243CDA1D331D002759E938A0F5CD3FFDC5D53B3E349",
       "display": "axlusdc",
       "denom_units": [
@@ -132,7 +132,7 @@
     {
       "name": "Wrapped USD Coin (Wormhole from Ethereum)",
       "description": "Wrapped USDC from Ethereum (Wormhole)",
-      "symbol": "USDCet",
+      "symbol": "USDC.eth",
       "base": "factory/sei189adguawugk3e55zn63z8r9ll29xrjwca636ra7v7gxuzn98sxyqwzt47l/Hq4tuDzhRBnxw3tFA5n6M52NVMVcC19XggbyDiJKCD6H",
       "display": "usdcet",
       "denom_units": [
@@ -198,7 +198,7 @@
     {
       "name": "Wrapped USD Coin (Wormhole from Arbitrum)",
       "description": "Wrapped USDC from Arbitrum (Wormhole)",
-      "symbol": "USDCar",
+      "symbol": "USDC.arb",
       "base": "factory/sei189adguawugk3e55zn63z8r9ll29xrjwca636ra7v7gxuzn98sxyqwzt47l/7edDfnf4mku8So3t4Do215GNHwASEwCWrdhM5GqD51xZ",
       "display": "usdcar",
       "denom_units": [
@@ -241,7 +241,7 @@
     {
       "name": "Wrapped USD Coin (Wormhole from Polygon)",
       "description": "Wrapped USDC from Polygon (Wormhole)",
-      "symbol": "USDCpo",
+      "symbol": "USDC.matic",
       "base": "factory/sei189adguawugk3e55zn63z8r9ll29xrjwca636ra7v7gxuzn98sxyqwzt47l/DUVFMY2neJdL8aE4d3stcpttDDm5aoyfGyVvm29iA9Yp",
       "display": "usdcpo",
       "denom_units": [
@@ -263,7 +263,7 @@
     {
       "name": "Wrapped USD Coin (Wormhole from Optimism)",
       "description": "Wrapped USDC from Optimism (Wormhole)",
-      "symbol": "USDCop",
+      "symbol": "USDC.op",
       "base": "factory/sei189adguawugk3e55zn63z8r9ll29xrjwca636ra7v7gxuzn98sxyqwzt47l/3VKKYtbQ9iq8f9CaZfgR6Cr3TUj6ypXPAn6kco6wjcAu",
       "display": "usdcop",
       "denom_units": [
@@ -285,7 +285,7 @@
     {
       "name": "Wrapped USD Coin (Wormhole from Solana)",
       "description": "Wrapped USDC from Solana (Wormhole)",
-      "symbol": "USDCso",
+      "symbol": "USDC.sol",
       "base": "factory/sei189adguawugk3e55zn63z8r9ll29xrjwca636ra7v7gxuzn98sxyqwzt47l/9fELvUhFo6yWL34ZaLgPbCPzdk9MD1tAzMycgH45qShH",
       "display": "usdcso",
       "denom_units": [
@@ -307,7 +307,7 @@
     {
       "name": "Wrapped USD Coin (Wormhole from BSC)",
       "description": "Wrapped USDC from BSC (Wormhole)",
-      "symbol": "USDCbs",
+      "symbol": "USDC.bsc",
       "base": "factory/sei189adguawugk3e55zn63z8r9ll29xrjwca636ra7v7gxuzn98sxyqwzt47l/3Ri4N719RQfQaudHiB9CMCYACtK3aieoz1q1Ph24VdAb",
       "display": "usdcbs",
       "denom_units": [

--- a/assetlist.json
+++ b/assetlist.json
@@ -154,7 +154,7 @@
     {
       "name": "Wrapped Tether USD (Wormhole from Ethereum)",
       "description": "Wrapped Tether USD from Ethereum (Wormhole)",
-      "symbol": "USDTet",
+      "symbol": "USDT.eth",
       "base": "factory/sei189adguawugk3e55zn63z8r9ll29xrjwca636ra7v7gxuzn98sxyqwzt47l/HktfLoADCk9mnjv7XJiN4YXK9ayE6xinLzt8wzcsR2rY",
       "display": "usdtet",
       "denom_units": [
@@ -350,7 +350,7 @@
     {
       "name": "Wrapped USDT (Wormhole from BSC)",
       "description": "Binance-Peg BSC-USD from BSC (Wormhole)",
-      "symbol": "USDTbs",
+      "symbol": "USDT.bsc",
       "base": "factory/sei189adguawugk3e55zn63z8r9ll29xrjwca636ra7v7gxuzn98sxyqwzt47l/871jbn9unTavWsAe83f2Ma9GJWSv6BKsyWYLiQ6z3Pva",
       "display": "usdtbs",
       "denom_units": [

--- a/assetlist.json
+++ b/assetlist.json
@@ -23,7 +23,7 @@
     {
       "name": "USD Coin (Axelar)",
       "description": "Circle's stablecoin on Axelar",
-      "symbol": "axl.USDC",
+      "symbol": "USDC.axl",
       "base": "ibc/F082B65C88E4B6D5EF1DB243CDA1D331D002759E938A0F5CD3FFDC5D53B3E349",
       "display": "axlusdc",
       "denom_units": [


### PR DESCRIPTION
## Description
This PR proposes a change to the asset list definition, specifically for the USDC flavour tickers to improve it's clarity.

## Motivation
As an Astroport contributor, we got a lot of user feedback stating that the tickers were very confusing, and in some ways it was not clear to them which pools they should LP in, I'll be honest I had an hard time initially as well for example with `USDCpo` and `USDCso`.

We internally discussed how could we improve the UX and in addition to improving our asset icons we want to make the tickers more clear, we didn't want to make this change unilaterally hence why this PR is being submitted.