### PR TITLE
Reverted gas price reduction on pacific-1

### DIFF
--- a/gas.json
+++ b/gas.json
@@ -1,7 +1,7 @@
 {
   "pacific-1": {
     "denom": "usei",
-    "min_gas_price": 0.02,
+    "min_gas_price": 0.1,
     "module_adjustments": {
       "dex": {
         "sudo_gas_price": 0.01,


### PR DESCRIPTION
Revert gas changes on pacific-1 so wallet transactions don't get code 13 (insufficient fee)