### PR TITLE
Update Arctic-1 Gas Multiplier Params

### DIFF
--- a/gas.json
+++ b/gas.json
@@ -23,12 +23,12 @@
   },
   "arctic-1": {
     "denom": "usei",
-    "min_gas_price": 0.02,
+    "min_gas_price": 0.08,
     "module_adjustments": {
       "dex": {
-        "sudo_gas_price": 0.01,
-        "order_placement": 55000,
-        "order_cancellation": 55000
+        "sudo_gas_price": 0.4,
+        "order_placement": 13750,
+        "order_cancellation": 13250
       }
     }
   },


### PR DESCRIPTION
- Update arctic-1 gas prices, gas used to reflect param change proposal 


```> seid q params cosmosgasparams
cosmos_gas_multiplier_denominator: "4"
cosmos_gas_multiplier_numerator: "1"

> seid q params feesparams
global_minimum_gas_prices:
- amount: "0.080000000000000000"
  denom: usei
> seid q params blockparams
max_bytes: "22020096"
max_gas: "2100000"

> seid q dex params
params:
  begin_block_gas_limit: "50000000"
  contract_unsuspend_cost: "1000000"
  default_gas_per_cancel: "13250"
  default_gas_per_order: "13750"
  default_gas_per_order_data_byte: "30"
  end_block_gas_limit: "250000000"
  gas_allowance_per_settlement: "2500"
  max_order_per_price: "10000"
  max_pairs_per_contract: "100"
  min_processable_rent: "100000"
  min_rent_deposit: "10000000"
  order_book_entries_per_load: "10"
  price_snapshot_retention: "86400"
  sudo_call_gas_price: "0.400000000000000000"```