### PR TITLE
Add Noble testnet to ibc_info.json

### DIFF
--- a/ibc_info.json
+++ b/ibc_info.json
@@ -78,6 +78,13 @@
       "src_channel": "channel-69",
       "port_id": "wasm.sei1nna9mzp274djrgzhzkac2gvm3j27l402s4xzr08chq57pjsupqnqaj0d5s",
       "client_id": "07-tendermint-117"
+    },
+    {
+      "counterparty_chain_name": "grand-1",
+      "dst_channel": "channel-23",
+      "src_channel": "channel-75",
+      "port_id": "transfer",
+      "client_id": "07-tendermint-188"
     }
   ],
   "arctic-1": [


### PR DESCRIPTION
Assuming [proposal 163](https://seitrace.com/proposal/163?chain=atlantic-2) passes this will be correct info. Replacing client with a new one which has 5 day trusting period just to confirm it works ahead of time.